### PR TITLE
feat: インフラ構成を再編成してGitHub Actions責務を明確化

### DIFF
--- a/.github/workflows/platform-deploy.yml
+++ b/.github/workflows/platform-deploy.yml
@@ -1,0 +1,168 @@
+name: Deploy Platform Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'platform/**'
+      - 'modules/**'
+      - '.github/workflows/platform-deploy.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'platform/**'
+      - 'modules/**'
+      - '.github/workflows/platform-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
+          - development
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+  pull-requests: write
+
+env:
+  AWS_REGION: ap-northeast-1
+  TF_VERSION: 1.5.7
+
+jobs:
+  terraform-plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    outputs:
+      exitcode: ${{ steps.plan.outputs.exitcode }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        working-directory: ./platform/self-healing-cicd
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: ./platform/self-healing-cicd
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        working-directory: ./platform/self-healing-cicd
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -detailed-exitcode -no-color -out=tfplan \
+            -var="github_token=${{ secrets.GH_PAT }}" \
+            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT }}" \
+            -var="ai_agent_api_key=${{ secrets.AI_AGENT_API_KEY }}"
+        working-directory: ./platform/self-healing-cicd
+        continue-on-error: true
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Comment PR with Plan
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PLAN: "${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Platform Infrastructure Plan 📖
+            #### Terraform Format and Style 🖌 \`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️ \`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖 \`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📋 \`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`terraform
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+  terraform-apply:
+    name: Terraform Apply
+    needs: terraform-plan
+    if: |
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push' &&
+      needs.terraform-plan.outputs.exitcode == '2'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ./platform/self-healing-cicd
+
+      - name: Terraform Apply
+        run: |
+          terraform apply -auto-approve -input=false \
+            -var="github_token=${{ secrets.GH_PAT }}" \
+            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT }}" \
+            -var="ai_agent_api_key=${{ secrets.AI_AGENT_API_KEY }}"
+        working-directory: ./platform/self-healing-cicd
+
+      - name: Display Outputs
+        run: |
+          echo "### Platform Infrastructure Deployed Successfully! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Key Outputs:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **CodeBuild Project**: $(terraform output -raw codebuild_project_name 2>/dev/null || echo 'N/A')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Lambda Function**: $(terraform output -raw lambda_function_name 2>/dev/null || echo 'N/A')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dashboard URL**: $(terraform output -raw cloudwatch_dashboard_url 2>/dev/null || echo 'N/A')" >> $GITHUB_STEP_SUMMARY
+        working-directory: ./platform/self-healing-cicd

--- a/.github/workflows/platform-deploy.yml
+++ b/.github/workflows/platform-deploy.yml
@@ -40,6 +40,7 @@ jobs:
   terraform-plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       exitcode: ${{ steps.plan.outputs.exitcode }}
 
@@ -79,7 +80,8 @@ jobs:
         run: |
           terraform plan -detailed-exitcode -no-color -out=tfplan \
             -var="github_token=${{ secrets.GH_PAT }}" \
-            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT }}" \
+            -var="github_repository=https://github.com/Frexida/infra.git" \
+            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT || 'https://api.frexida.com/ci-result' }}" \
             -var="ai_agent_api_key=${{ secrets.AI_AGENT_API_KEY }}"
         working-directory: ./platform/self-healing-cicd
         continue-on-error: true
@@ -152,7 +154,8 @@ jobs:
         run: |
           terraform apply -auto-approve -input=false \
             -var="github_token=${{ secrets.GH_PAT }}" \
-            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT }}" \
+            -var="github_repository=https://github.com/Frexida/infra.git" \
+            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT || 'https://api.frexida.com/ci-result' }}" \
             -var="ai_agent_api_key=${{ secrets.AI_AGENT_API_KEY }}"
         working-directory: ./platform/self-healing-cicd
 

--- a/.github/workflows/project-deploy.yml
+++ b/.github/workflows/project-deploy.yml
@@ -1,0 +1,246 @@
+name: Deploy Project Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'projects/**'
+      - 'modules/**'
+      - '.github/workflows/project-deploy.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'projects/**'
+      - 'modules/**'
+      - '.github/workflows/project-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'Project to deploy'
+        required: true
+        type: choice
+        options:
+          - picture-calendar
+          - homepage
+          - app-foobar
+          - all
+      environment:
+        description: 'Environment'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
+          - development
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+  pull-requests: write
+
+env:
+  AWS_REGION: ap-northeast-1
+  TF_VERSION: 1.5.7
+
+jobs:
+  detect-changes:
+    name: Detect Project Changes
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.detect.outputs.projects }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed projects
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            if [ "${{ github.event.inputs.project }}" == "all" ]; then
+              projects='["picture-calendar", "homepage", "app-foobar"]'
+            else
+              projects='["${{ github.event.inputs.project }}"]'
+            fi
+          else
+            # Detect which projects have changes
+            changed_files=$(git diff --name-only HEAD^ HEAD)
+            projects='[]'
+
+            if echo "$changed_files" | grep -q "projects/picture-calendar/"; then
+              projects=$(echo $projects | jq '. += ["picture-calendar"]')
+            fi
+            if echo "$changed_files" | grep -q "projects/homepage/"; then
+              projects=$(echo $projects | jq '. += ["homepage"]')
+            fi
+            if echo "$changed_files" | grep -q "projects/app-foobar/"; then
+              projects=$(echo $projects | jq '. += ["app-foobar"]')
+            fi
+
+            # If modules changed, deploy all projects
+            if echo "$changed_files" | grep -q "modules/"; then
+              projects='["picture-calendar", "homepage", "app-foobar"]'
+            fi
+          fi
+
+          echo "projects=$projects" >> $GITHUB_OUTPUT
+          echo "matrix={\"project\":$projects}" >> $GITHUB_OUTPUT
+          echo "Projects to deploy: $projects"
+
+  terraform-plan:
+    name: Plan ${{ matrix.project }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.projects != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        working-directory: ./projects/${{ matrix.project }}/terraform
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: ./projects/${{ matrix.project }}/terraform
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        working-directory: ./projects/${{ matrix.project }}/terraform
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -detailed-exitcode -no-color -out=tfplan \
+            -var="github_token=${{ secrets.GH_PAT }}" \
+            -var="ai_agent_endpoint=${{ vars.AI_AGENT_ENDPOINT }}" \
+            -var="ai_agent_api_key=${{ secrets.AI_AGENT_API_KEY }}"
+        working-directory: ./projects/${{ matrix.project }}/terraform
+        continue-on-error: true
+
+      - name: Upload Plan
+        if: steps.plan.outputs.exitcode == '2'
+        uses: actions/upload-artifact@v3
+        with:
+          name: tfplan-${{ matrix.project }}
+          path: ./projects/${{ matrix.project }}/terraform/tfplan
+
+      - name: Comment PR with Plan
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PLAN: "${{ steps.plan.outputs.stdout }}"
+          PROJECT: "${{ matrix.project }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Project: ${process.env.PROJECT} 🏗️
+            #### Terraform Format and Style 🖌 \`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️ \`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖 \`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📋 \`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan for ${process.env.PROJECT}</summary>
+
+            \`\`\`terraform
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+  terraform-apply:
+    name: Apply ${{ matrix.project }}
+    needs: [detect-changes, terraform-plan]
+    if: |
+      github.ref == 'refs/heads/main' &&
+      github.event_name != 'pull_request' &&
+      needs.detect-changes.outputs.projects != '[]'
+    runs-on: ubuntu-latest
+    environment: production
+    strategy:
+      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ./projects/${{ matrix.project }}/terraform
+
+      - name: Download Plan
+        uses: actions/download-artifact@v3
+        with:
+          name: tfplan-${{ matrix.project }}
+          path: ./projects/${{ matrix.project }}/terraform
+
+      - name: Terraform Apply
+        run: |
+          terraform apply -auto-approve -input=false tfplan
+        working-directory: ./projects/${{ matrix.project }}/terraform
+
+      - name: Get Outputs
+        id: outputs
+        run: |
+          echo "webhook_url=$(terraform output -raw webhook_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "codebuild_project=$(terraform output -raw codebuild_project_name 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "dashboard_url=$(terraform output -raw cloudwatch_dashboard_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+        working-directory: ./projects/${{ matrix.project }}/terraform
+
+      - name: Summary
+        run: |
+          echo "### Project ${{ matrix.project }} Deployed Successfully! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Resources Created:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **CodeBuild Project**: ${{ steps.outputs.outputs.codebuild_project }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dashboard**: ${{ steps.outputs.outputs.dashboard_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Next Steps:" >> $GITHUB_STEP_SUMMARY
+          echo "1. Add webhook URL to GitHub repository settings" >> $GITHUB_STEP_SUMMARY
+          echo "2. Ensure buildspec.yml exists in the project repository" >> $GITHUB_STEP_SUMMARY
+          echo "3. Monitor builds in CloudWatch dashboard" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/project-deploy.yml
+++ b/.github/workflows/project-deploy.yml
@@ -68,24 +68,57 @@ jobs:
             else
               projects='["${{ github.event.inputs.project }}"]'
             fi
-          else
-            # Detect which projects have changes
-            changed_files=$(git diff --name-only HEAD^ HEAD)
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For PRs, check changed files against base branch
+            changed_files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
             projects='[]'
 
+            # Build projects array manually without jq
+            project_list=""
+
             if echo "$changed_files" | grep -q "projects/picture-calendar/"; then
-              projects=$(echo $projects | jq '. += ["picture-calendar"]')
+              [ -z "$project_list" ] && project_list='"picture-calendar"' || project_list="$project_list,\"picture-calendar\""
             fi
             if echo "$changed_files" | grep -q "projects/homepage/"; then
-              projects=$(echo $projects | jq '. += ["homepage"]')
+              [ -z "$project_list" ] && project_list='"homepage"' || project_list="$project_list,\"homepage\""
             fi
             if echo "$changed_files" | grep -q "projects/app-foobar/"; then
-              projects=$(echo $projects | jq '. += ["app-foobar"]')
+              [ -z "$project_list" ] && project_list='"app-foobar"' || project_list="$project_list,\"app-foobar\""
             fi
 
             # If modules changed, deploy all projects
             if echo "$changed_files" | grep -q "modules/"; then
               projects='["picture-calendar", "homepage", "app-foobar"]'
+            elif [ -n "$project_list" ]; then
+              projects="[$project_list]"
+            else
+              projects='[]'
+            fi
+          else
+            # For push events
+            changed_files=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+            projects='[]'
+
+            # Build projects array manually without jq
+            project_list=""
+
+            if echo "$changed_files" | grep -q "projects/picture-calendar/"; then
+              [ -z "$project_list" ] && project_list='"picture-calendar"' || project_list="$project_list,\"picture-calendar\""
+            fi
+            if echo "$changed_files" | grep -q "projects/homepage/"; then
+              [ -z "$project_list" ] && project_list='"homepage"' || project_list="$project_list,\"homepage\""
+            fi
+            if echo "$changed_files" | grep -q "projects/app-foobar/"; then
+              [ -z "$project_list" ] && project_list='"app-foobar"' || project_list="$project_list,\"app-foobar\""
+            fi
+
+            # If modules changed, deploy all projects
+            if echo "$changed_files" | grep -q "modules/"; then
+              projects='["picture-calendar", "homepage", "app-foobar"]'
+            elif [ -n "$project_list" ]; then
+              projects="[$project_list]"
+            else
+              projects='[]'
             fi
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,25 @@
 .env
 .env.local
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+*.tfplan
+*.tfvars
+!example.tfvars
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/platform/self-healing-cicd/README.md
+++ b/platform/self-healing-cicd/README.md
@@ -1,0 +1,243 @@
+# Platform Self-Healing CI/CD Infrastructure
+
+This directory contains the platform-level infrastructure for Frexida's self-healing CI/CD system.
+
+## Overview
+
+This is the **organization-wide CI/CD platform** that provides:
+- Centralized error handling with AI-powered recovery
+- Shared Lambda functions for all projects
+- Common monitoring and alerting infrastructure
+- Reusable CodeBuild configurations
+
+## Architecture
+
+```
+┌──────────────────┐     ┌─────────────────┐     ┌──────────────────┐
+│  GitHub Webhook  │────▶│  AWS CodeBuild  │────▶│  Build Success   │
+└──────────────────┘     └─────────────────┘     └──────────────────┘
+                                  │
+                                  │ Failure
+                                  ▼
+                         ┌─────────────────┐
+                         │  SNS Topic      │
+                         └─────────────────┘
+                                  │
+                                  ▼
+                         ┌─────────────────┐
+                         │  Lambda Function│
+                         └─────────────────┘
+                                  │
+                                  ▼
+                         ┌─────────────────┐
+                         │  AI Agent API   │
+                         └─────────────────┘
+```
+
+## Resources Managed
+
+- **Lambda Function**: `ai-error-handler` - Processes build failures
+- **SNS Topics**: Build failure notifications
+- **EventBridge Rules**: Trigger Lambda on CodeBuild failures
+- **CloudWatch Dashboards**: Centralized monitoring
+- **IAM Roles**: Service permissions
+- **Secrets Manager**: API keys and tokens
+
+## Prerequisites
+
+1. **AWS Backend Infrastructure**:
+   ```bash
+   # S3 bucket for Terraform state
+   aws s3 mb s3://frexida-terraform-state --region ap-northeast-1
+
+   # DynamoDB table for state locking
+   aws dynamodb create-table \
+     --table-name terraform-lock \
+     --attribute-definitions AttributeName=LockID,AttributeType=S \
+     --key-schema AttributeName=LockID,KeyType=HASH \
+     --billing-mode PAY_PER_REQUEST \
+     --region ap-northeast-1
+   ```
+
+2. **GitHub Actions OIDC**:
+   ```bash
+   # Create OIDC provider (if not exists)
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+   ```
+
+3. **IAM Role for GitHub Actions**:
+   Use the template at `templates/iam/trust-policy-terraform-role.json`
+
+## Deployment
+
+### Via GitHub Actions (Recommended)
+
+1. **Configure GitHub Secrets**:
+   - `AWS_ROLE_ARN`: IAM role for OIDC authentication
+   - `GH_PAT`: GitHub Personal Access Token
+   - `AI_AGENT_API_KEY`: AI Agent API key (if required)
+
+2. **Configure GitHub Variables**:
+   - `AI_AGENT_ENDPOINT`: AI Agent API URL
+
+3. **Push to main branch**:
+   ```bash
+   git push origin main
+   ```
+   The workflow will automatically deploy when changes are detected in:
+   - `platform/` directory
+   - `modules/` directory
+
+### Manual Deployment
+
+1. **Set environment variables**:
+   ```bash
+   export TF_VAR_github_token="ghp_..."
+   export TF_VAR_ai_agent_endpoint="https://api.frexida.com/ci_result"
+   export TF_VAR_ai_agent_api_key="optional-api-key"
+   ```
+
+2. **Initialize and apply**:
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+## State Migration (If Upgrading)
+
+If migrating from the old structure (`terraform/` directory):
+
+1. **Backup existing state**:
+   ```bash
+   cd ../../terraform
+   terraform state pull > ../backup-state.json
+   ```
+
+2. **Initialize new location**:
+   ```bash
+   cd ../platform/self-healing-cicd
+   terraform init -reconfigure
+   ```
+
+3. **Import existing state**:
+   ```bash
+   terraform state push ../../backup-state.json
+   ```
+
+4. **Verify no changes**:
+   ```bash
+   terraform plan  # Should show no changes
+   ```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Required | Default |
+|----------|-------------|----------|---------|
+| `TF_VAR_github_token` | GitHub PAT with repo permissions | Yes | - |
+| `TF_VAR_github_repository` | GitHub repository URL | Yes | - |
+| `TF_VAR_ai_agent_endpoint` | AI Agent API endpoint | Yes | - |
+| `TF_VAR_ai_agent_api_key` | AI Agent API key | No | "" |
+| `TF_VAR_github_webhook_secret` | Webhook validation secret | No | "" |
+| `TF_VAR_environment` | Environment name | No | "production" |
+| `TF_VAR_aws_region` | AWS region | No | "ap-northeast-1" |
+
+### Cost Optimization
+
+Current configuration is optimized for < 3,000 JPY/month:
+- CodeBuild: BUILD_GENERAL1_SMALL (2 vCPU, 3GB RAM)
+- Lambda: Within free tier
+- CloudWatch Logs: 7-day retention
+- DynamoDB: On-demand billing
+
+## Monitoring
+
+### CloudWatch Dashboard
+
+Access the dashboard:
+```bash
+terraform output cloudwatch_dashboard_url
+```
+
+Metrics tracked:
+- Build success/failure rates
+- Lambda execution times
+- Retry counts
+- Cost estimates
+
+### Alarms
+
+Configured alarms:
+- High failure rate (>50% in 5 minutes)
+- Infinite retry loops (>5 retries)
+- High costs (>3,000 JPY/month projected)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **State Lock Error**:
+   ```bash
+   # Force unlock if stuck
+   terraform force-unlock <lock-id>
+   ```
+
+2. **OIDC Authentication Failed**:
+   - Verify IAM role trust policy
+   - Check GitHub Actions permissions
+   - Ensure repository is in allowed list
+
+3. **Lambda Function Not Triggering**:
+   - Check EventBridge rule is enabled
+   - Verify SNS subscription
+   - Review Lambda permissions
+
+### Debug Commands
+
+```bash
+# View Lambda logs
+aws logs tail /aws/lambda/ai-error-handler --follow
+
+# Check CodeBuild project
+aws codebuild list-builds-for-project \
+  --project-name frexida-app-pipeline
+
+# Test Lambda locally
+cd lambda/ai-error-handler
+python index.py
+```
+
+## Maintenance
+
+### Updating Lambda Function
+
+1. Modify code in `lambda/ai-error-handler/`
+2. Package and deploy:
+   ```bash
+   cd lambda/ai-error-handler
+   zip -r lambda-package.zip .
+   terraform apply -target=module.self_healing_cicd.aws_lambda_function.error_handler
+   ```
+
+### Rotating Secrets
+
+```bash
+# Update GitHub token
+aws secretsmanager put-secret-value \
+  --secret-id github-pat \
+  --secret-string "new-token"
+
+# Trigger Lambda to use new token
+terraform apply -replace=module.self_healing_cicd.aws_lambda_function.error_handler
+```
+
+## Related Documentation
+
+- [Module Documentation](../../modules/self-healing-cicd/README.md)
+- [Project Configurations](../../projects/README.md)
+- [Architecture Decision](../../docs/architecture-decision.md)

--- a/platform/self-healing-cicd/backend.tf
+++ b/platform/self-healing-cicd/backend.tf
@@ -1,0 +1,10 @@
+# Remote state backend for platform infrastructure
+terraform {
+  backend "s3" {
+    bucket         = "frexida-terraform-state"
+    key            = "platform/self-healing-cicd/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/platform/self-healing-cicd/lambda/ai-error-handler/index.py
+++ b/platform/self-healing-cicd/lambda/ai-error-handler/index.py
@@ -1,0 +1,316 @@
+"""
+AI Error Handler Lambda Function
+Handles CodeBuild failures and sends error information to AI Agent API
+"""
+
+import json
+import os
+import boto3
+import requests
+from datetime import datetime, timedelta
+from typing import Dict, Any, Optional
+import time
+
+# AWS clients
+logs_client = boto3.client('logs')
+secrets_client = boto3.client('secretsmanager')
+codebuild_client = boto3.client('codebuild')
+dynamodb = boto3.resource('dynamodb')
+cloudwatch = boto3.client('cloudwatch')
+
+# Configuration
+AI_AGENT_ENDPOINT = os.environ['AI_AGENT_ENDPOINT']
+MAX_RETRY_COUNT = int(os.environ.get('MAX_RETRY_COUNT', 3))
+RETRY_TABLE = dynamodb.Table(os.environ['DYNAMODB_TABLE'])
+
+
+def handler(event, context):
+    """
+    Handle CodeBuild failure events and send error information to AI agent
+    """
+    try:
+        print(f"Received event: {json.dumps(event)}")
+
+        # Parse event based on source (SNS or EventBridge)
+        if 'Records' in event and event['Records'][0].get('EventSource') == 'aws:sns':
+            # SNS message
+            message = json.loads(event['Records'][0]['Sns']['Message'])
+        else:
+            # Direct EventBridge event
+            message = event
+
+        # Extract build information
+        build_id = message['detail']['build-id']
+        project_name = message['detail']['project-name']
+        build_status = message['detail']['build-status']
+
+        # Only process failures
+        if build_status != 'FAILED':
+            print(f"Build status is {build_status}, not processing")
+            return {
+                'statusCode': 200,
+                'body': json.dumps({'message': 'Not a failure, skipping'})
+            }
+
+        print(f"Processing build failure: {build_id}")
+        print(f"Project: {project_name}, Status: {build_status}")
+
+        # Check retry count to prevent infinite loops
+        retry_count = get_retry_count(build_id)
+        if retry_count >= MAX_RETRY_COUNT:
+            print(f"Max retry count ({MAX_RETRY_COUNT}) reached for {build_id}. Stopping.")
+            send_metric('MaxRetryReached', 1)
+            send_max_retry_notification(build_id, project_name)
+            return {
+                'statusCode': 200,
+                'body': json.dumps({'message': 'Max retries exceeded'})
+            }
+
+        # Wait briefly for logs to be written
+        time.sleep(3)
+
+        # Get build metadata
+        build_info = codebuild_client.batch_get_builds(ids=[build_id])
+        build_metadata = build_info['builds'][0]
+
+        # Retrieve error logs from CloudWatch
+        log_group = f"/aws/codebuild/{project_name}"
+        log_stream = build_id.split(':')[-1]
+
+        error_logs = get_build_logs(log_group, log_stream)
+
+        # Prepare simplified payload for AI agent
+        agent_payload = {
+            'buildStatus': 'FAILED',
+            'buildId': build_id,
+            'projectName': project_name,
+            'logGroup': log_group,
+            'logStream': log_stream,
+            'errorLogs': error_logs,
+            'commitHash': build_metadata.get('resolvedSourceVersion', '')[:7],
+            'branch': build_metadata.get('sourceVersion', '').replace('refs/heads/', ''),
+            'retryCount': retry_count,
+            'timestamp': datetime.utcnow().isoformat() + 'Z'
+        }
+
+        print(f"Sending error information to AI agent: {AI_AGENT_ENDPOINT}")
+
+        # Send to AI agent
+        response = send_to_ai_agent(agent_payload)
+
+        if response and response.status_code == 200:
+            print("Successfully sent error information to AI agent")
+            # Increment retry count for tracking
+            increment_retry_count(build_id)
+            send_metric('AIAgentNotified', 1)
+        else:
+            print(f"Failed to notify AI agent: {response.status_code if response else 'No response'}")
+            send_metric('AIAgentNotificationFailed', 1)
+
+        # Send metrics
+        send_metric('BuildFailures', 1)
+        send_metric('RetryCount', retry_count)
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps({'message': 'Build failure processed'})
+        }
+
+    except Exception as e:
+        print(f"Error processing build failure: {str(e)}")
+        send_metric('LambdaErrors', 1)
+        return {
+            'statusCode': 500,
+            'body': json.dumps({'error': str(e)})
+        }
+
+
+def get_build_logs(log_group: str, log_stream: str, limit: int = 500) -> str:
+    """
+    Retrieve error logs from CloudWatch Logs
+    """
+    try:
+        # Check if log stream exists
+        response = logs_client.describe_log_streams(
+            logGroupName=log_group,
+            logStreamNamePrefix=log_stream,
+            limit=1
+        )
+
+        if not response.get('logStreams'):
+            print(f"Log stream {log_stream} not found")
+            return "Log stream not yet available"
+
+        # Get the last N log lines
+        response = logs_client.get_log_events(
+            logGroupName=log_group,
+            logStreamName=log_stream,
+            startFromHead=False,
+            limit=limit
+        )
+
+        # Extract all log lines
+        log_lines = [event['message'] for event in response.get('events', [])]
+
+        # Filter for error-related lines (keep context)
+        error_keywords = ['ERROR', 'FAILED', 'Error', 'error', 'npm ERR',
+                         'pytest', 'FAIL', 'Exception', 'Traceback', 'fatal']
+
+        error_lines = []
+        include_next = 0
+
+        for i, line in enumerate(log_lines):
+            if any(keyword in line for keyword in error_keywords):
+                # Include 3 lines before error for context
+                for j in range(max(0, i-3), i):
+                    if log_lines[j] not in error_lines:
+                        error_lines.append(log_lines[j])
+                error_lines.append(line)
+                include_next = 5  # Include next 5 lines after error
+            elif include_next > 0:
+                error_lines.append(line)
+                include_next -= 1
+
+        # If no specific errors found, return last 100 lines
+        if not error_lines:
+            error_lines = log_lines[-100:]
+
+        return '\n'.join(error_lines)
+
+    except logs_client.exceptions.ResourceNotFoundException:
+        print(f"Log group {log_group} not found")
+        return f"Log group {log_group} not found"
+    except Exception as e:
+        print(f"Error retrieving logs: {str(e)}")
+        return f"Error retrieving logs: {str(e)}"
+
+
+def send_to_ai_agent(payload: Dict[str, Any]) -> Optional[requests.Response]:
+    """
+    Send error information to AI agent API
+    Simple POST request with error details
+    """
+    try:
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        # Optional: Add API key if configured
+        api_key_arn = os.environ.get('AI_AGENT_API_KEY_ARN')
+        if api_key_arn and api_key_arn != "":
+            api_key = get_secret(api_key_arn)
+            headers['Authorization'] = f'Bearer {api_key}'
+
+        print(f"Sending POST request to: {AI_AGENT_ENDPOINT}")
+        print(f"Payload size: {len(json.dumps(payload))} bytes")
+
+        response = requests.post(
+            AI_AGENT_ENDPOINT,
+            json=payload,
+            headers=headers,
+            timeout=30  # 30 second timeout
+        )
+
+        print(f"AI agent response status: {response.status_code}")
+
+        if response.status_code == 200:
+            print("AI agent acknowledged the error notification")
+        else:
+            print(f"AI agent response: {response.text[:500]}")  # Log first 500 chars
+
+        return response
+
+    except requests.exceptions.Timeout:
+        print("AI agent request timed out")
+        return None
+    except requests.exceptions.RequestException as e:
+        print(f"Error calling AI agent: {str(e)}")
+        return None
+    except Exception as e:
+        print(f"Unexpected error: {str(e)}")
+        return None
+
+
+def get_retry_count(build_id: str) -> int:
+    """
+    Get current retry count from DynamoDB
+    """
+    try:
+        response = RETRY_TABLE.get_item(Key={'build_id': build_id})
+        item = response.get('Item', {})
+        return item.get('retry_count', 0)
+    except Exception as e:
+        print(f"Error getting retry count: {str(e)}")
+        return 0
+
+
+def increment_retry_count(build_id: str):
+    """
+    Increment retry count in DynamoDB with TTL
+    """
+    try:
+        # Set expiration time to 24 hours from now
+        expiration_time = int((datetime.now() + timedelta(hours=24)).timestamp())
+
+        RETRY_TABLE.update_item(
+            Key={'build_id': build_id},
+            UpdateExpression='SET retry_count = if_not_exists(retry_count, :zero) + :inc, expiration_time = :exp',
+            ExpressionAttributeValues={
+                ':inc': 1,
+                ':zero': 0,
+                ':exp': expiration_time
+            }
+        )
+        print(f"Incremented retry count for {build_id}")
+    except Exception as e:
+        print(f"Error updating retry count: {str(e)}")
+
+
+def get_secret(secret_arn: str) -> str:
+    """
+    Retrieve secret from AWS Secrets Manager
+    """
+    try:
+        response = secrets_client.get_secret_value(SecretId=secret_arn)
+        return response['SecretString']
+    except Exception as e:
+        print(f"Error retrieving secret: {str(e)}")
+        raise
+
+
+def send_metric(metric_name: str, value: float, unit: str = 'Count'):
+    """
+    Send custom metric to CloudWatch
+    """
+    try:
+        cloudwatch.put_metric_data(
+            Namespace='SelfHealingPipeline',
+            MetricData=[
+                {
+                    'MetricName': metric_name,
+                    'Value': value,
+                    'Unit': unit,
+                    'Timestamp': datetime.utcnow()
+                }
+            ]
+        )
+    except Exception as e:
+        print(f"Error sending metric {metric_name}: {str(e)}")
+
+
+def send_max_retry_notification(build_id: str, project_name: str):
+    """
+    Send notification when max retries reached
+    """
+    try:
+        # Log the event
+        print(f"ALERT: Max retries reached for build {build_id} in project {project_name}")
+
+        # Send a metric for alerting
+        send_metric('MaxRetryExceeded', 1)
+
+        # Could also send to SNS, Slack, etc. if configured
+        # For now, just log it prominently
+
+    except Exception as e:
+        print(f"Error sending max retry notification: {str(e)}")

--- a/platform/self-healing-cicd/lambda/ai-error-handler/requirements.txt
+++ b/platform/self-healing-cicd/lambda/ai-error-handler/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.31.0
+PyGithub==2.1.1
+boto3==1.34.14

--- a/platform/self-healing-cicd/main.tf
+++ b/platform/self-healing-cicd/main.tf
@@ -82,7 +82,7 @@ module "self_healing_cicd" {
   # GitHub configuration
   github_repository = var.github_repository
   github_branch     = "main"
-  github_token      = var.github_token  # Set via environment variable
+  github_token      = var.github_token # Set via environment variable
   webhook_secret    = var.github_webhook_secret
 
   # AI Agent configuration
@@ -90,10 +90,10 @@ module "self_healing_cicd" {
   ai_agent_api_key  = var.ai_agent_api_key
 
   # Build configuration (optimized for cost)
-  build_compute_type = "BUILD_GENERAL1_SMALL"  # 2 vCPU, 3GB RAM
-  build_timeout      = 30                      # 30 minutes max
-  max_retry_count    = 3                       # Max 3 automatic retries
-  log_retention_days = 7                       # Keep logs for 7 days
+  build_compute_type = "BUILD_GENERAL1_SMALL" # 2 vCPU, 3GB RAM
+  build_timeout      = 30                     # 30 minutes max
+  max_retry_count    = 3                      # Max 3 automatic retries
+  log_retention_days = 7                      # Keep logs for 7 days
 }
 
 ###############################################################################

--- a/platform/self-healing-cicd/main.tf
+++ b/platform/self-healing-cicd/main.tf
@@ -1,0 +1,157 @@
+###############################################################################
+# Frexida Self-Healing CI/CD Pipeline
+#
+# GitHub Token is configured with the provided PAT
+###############################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Backend configuration is in backend.tf
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Variables
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "github_repository" {
+  description = "GitHub repository URL"
+  type        = string
+}
+
+variable "github_token" {
+  description = "GitHub Personal Access Token"
+  type        = string
+  sensitive   = true
+}
+
+variable "ai_agent_endpoint" {
+  description = "AI Agent API endpoint URL"
+  type        = string
+}
+
+variable "ai_agent_api_key" {
+  description = "API key for AI agent service (optional)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "github_webhook_secret" {
+  description = "Secret for GitHub webhook validation (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# Get current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# Self-healing CI/CD module with provided GitHub token
+module "self_healing_cicd" {
+  source = "../../modules/self-healing-cicd"
+
+  # Environment configuration
+  environment = var.environment
+  aws_region  = var.aws_region
+  account_id  = data.aws_caller_identity.current.account_id
+
+  # Project configuration
+  project_name = "frexida-self-healing-pipeline"
+
+  # GitHub configuration
+  github_repository = var.github_repository
+  github_branch     = "main"
+  github_token      = var.github_token  # Set via environment variable
+  webhook_secret    = var.github_webhook_secret
+
+  # AI Agent configuration
+  ai_agent_endpoint = var.ai_agent_endpoint
+  ai_agent_api_key  = var.ai_agent_api_key
+
+  # Build configuration (optimized for cost)
+  build_compute_type = "BUILD_GENERAL1_SMALL"  # 2 vCPU, 3GB RAM
+  build_timeout      = 30                      # 30 minutes max
+  max_retry_count    = 3                       # Max 3 automatic retries
+  log_retention_days = 7                       # Keep logs for 7 days
+}
+
+###############################################################################
+# Outputs
+###############################################################################
+
+output "webhook_url" {
+  description = "GitHub webhook URL - Add this to your repository settings"
+  value       = module.self_healing_cicd.webhook_url
+  sensitive   = true
+}
+
+output "cloudwatch_dashboard_url" {
+  description = "CloudWatch dashboard URL for monitoring"
+  value       = module.self_healing_cicd.cloudwatch_dashboard_url
+}
+
+output "codebuild_project_name" {
+  description = "CodeBuild project name"
+  value       = module.self_healing_cicd.codebuild_project_name
+}
+
+output "lambda_function_name" {
+  description = "Lambda function name for error handling"
+  value       = module.self_healing_cicd.lambda_function_name
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for build failure notifications"
+  value       = module.self_healing_cicd.sns_topic_arn
+}
+
+output "instructions" {
+  value = <<-EOT
+
+  ============================================================
+  Self-Healing CI/CD Pipeline Setup Complete!
+  ============================================================
+
+  1. Get the webhook URL:
+     terraform output -raw webhook_url
+
+  2. Add webhook to GitHub:
+     - Go to: ${var.github_repository}/settings/hooks
+     - Click "Add webhook"
+     - Paste the webhook URL
+     - Content type: application/json
+     - Select: Just the push event
+     - Click "Add webhook"
+
+  3. Add buildspec.yml to your repository root
+     Copy from: modules/self-healing-cicd/buildspec.yml
+
+  4. Monitor your pipeline:
+     ${module.self_healing_cicd.cloudwatch_dashboard_url}
+
+  5. Test by pushing code with an intentional error!
+
+  ============================================================
+  EOT
+}

--- a/platform/self-healing-cicd/terraform.tfvars.example
+++ b/platform/self-healing-cicd/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Terraform変数の設定例
+# このファイルをコピーして terraform.tfvars として使用してください
+# cp terraform.tfvars.example terraform.tfvars
+
+# 環境設定
+environment = "production"
+aws_region  = "ap-northeast-1"
+
+# GitHub Personal Access Token (必須)
+# このトークンには以下の権限が必要です：
+# - repo (コードの読み取り、コミット、プッシュ)
+# 環境変数で設定: export TF_VAR_github_token="your-token"
+# または以下に直接記入（Gitにコミットしないよう注意）
+# github_token = "your-github-token"
+
+# AI Agent API設定
+# エラー情報を送信するエンドポイントURL
+# 例: https://your-ai-agent.com/ci_result
+ai_agent_endpoint = "https://your-ai-agent-api.com/ci_result"
+
+# オプション: API認証が必要な場合のみ設定
+# ai_agent_api_key = "your-optional-api-key"
+
+# オプション: GitHub Webhook検証用シークレット
+# github_webhook_secret = "your-webhook-secret"

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,193 @@
+# Project-Specific Infrastructure
+
+This directory contains infrastructure configurations for individual Frexida projects.
+
+## Directory Structure
+
+```
+projects/
+├── picture-calendar/     # Picture calendar application
+├── homepage/            # Frexida homepage
+└── app-foobar/         # Sample application
+```
+
+## Overview
+
+Each project directory contains its own Terraform configuration that:
+- Uses the shared `self-healing-cicd` module
+- Maintains separate Terraform state
+- Can be deployed independently
+- Inherits platform capabilities
+
+## Key Principles
+
+### 1. Module Reuse Only
+Projects **MUST** use the existing module without modification:
+
+```hcl
+module "project_cicd" {
+  source = "../../../modules/self-healing-cicd"
+
+  # Project-specific configuration only
+  project_name      = "my-project"
+  github_repository = "https://github.com/Frexida/my-project.git"
+  # ...
+}
+```
+
+### 2. No Infrastructure Duplication
+- Platform resources (Lambda, SNS) are shared
+- Each project gets its own CodeBuild project
+- Monitoring is centralized with project-specific views
+
+### 3. Separation of Concerns
+- **Platform**: Organization-wide resources
+- **Projects**: Application-specific pipelines
+- **Modules**: Reusable Terraform code
+
+## Adding a New Project
+
+### 1. Create Project Directory
+
+```bash
+mkdir -p projects/new-project/terraform
+cd projects/new-project/terraform
+```
+
+### 2. Create Configuration Files
+
+**main.tf**:
+```hcl
+module "new_project_cicd" {
+  source = "../../../modules/self-healing-cicd"
+
+  environment       = var.environment
+  aws_region       = var.aws_region
+  account_id       = data.aws_caller_identity.current.account_id
+
+  project_name     = "new-project"
+  github_repository = "https://github.com/Frexida/new-project.git"
+  github_branch    = "main"
+  github_token     = var.github_token
+
+  ai_agent_endpoint = var.ai_agent_endpoint
+  ai_agent_api_key  = var.ai_agent_api_key
+}
+```
+
+**backend.tf**:
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "frexida-terraform-state"
+    key            = "projects/new-project/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}
+```
+
+### 3. Deploy via GitHub Actions
+
+The project will be automatically deployed when:
+- Changes are pushed to `projects/new-project/`
+- The workflow is manually triggered
+- Module changes affect all projects
+
+## Deployment
+
+### Automatic Deployment
+
+Projects are deployed automatically via GitHub Actions when:
+1. Changes are pushed to the project directory
+2. Changes are made to shared modules
+3. Manual workflow dispatch is triggered
+
+### Manual Deployment
+
+For a specific project:
+```bash
+cd projects/picture-calendar/terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+## State Management
+
+Each project maintains independent Terraform state:
+- **picture-calendar**: `projects/picture-calendar/terraform.tfstate`
+- **homepage**: `projects/homepage/terraform.tfstate`
+- **app-foobar**: `projects/app-foobar/terraform.tfstate`
+
+This allows:
+- Independent deployment cycles
+- Isolated blast radius
+- Parallel development
+
+## Cost Allocation
+
+Each project is tagged for cost tracking:
+- Environment tag (production/staging/development)
+- Project tag (project name)
+- Managed-by tag (terraform)
+
+View costs per project in AWS Cost Explorer using these tags.
+
+## Best Practices
+
+### DO ✅
+- Use the shared module without modification
+- Keep project configurations minimal
+- Use consistent naming conventions
+- Document project-specific requirements
+- Tag resources appropriately
+
+### DON'T ❌
+- Duplicate infrastructure resources
+- Modify the shared module per project
+- Create project-specific Lambda functions
+- Bypass the CI/CD pipeline
+- Store secrets in code
+
+## Monitoring
+
+Each project has:
+- Dedicated CodeBuild project metrics
+- Project-specific CloudWatch dashboard widgets
+- Build history and logs
+- Cost tracking
+
+Access via:
+```bash
+terraform output cloudwatch_dashboard_url
+```
+
+## Troubleshooting
+
+### Project Not Building
+1. Verify webhook is configured in GitHub
+2. Check CodeBuild project exists
+3. Ensure buildspec.yml is in repository root
+4. Review CloudWatch logs
+
+### State Lock Issues
+```bash
+aws dynamodb delete-item \
+  --table-name terraform-lock \
+  --key "{\"LockID\": {\"S\": \"frexida-terraform-state/projects/<project>/terraform.tfstate\"}}"
+```
+
+### Module Version Conflicts
+All projects use the same module version. To update:
+1. Test changes in development
+2. Update module in one project
+3. Verify functionality
+4. Roll out to other projects
+
+## Related Documentation
+
+- [Platform Infrastructure](../platform/self-healing-cicd/README.md)
+- [Module Documentation](../modules/self-healing-cicd/README.md)
+- [GitHub Actions Workflows](../.github/workflows/README.md)

--- a/projects/app-foobar/terraform/backend.tf
+++ b/projects/app-foobar/terraform/backend.tf
@@ -1,0 +1,10 @@
+# Remote state backend for app-foobar project
+terraform {
+  backend "s3" {
+    bucket         = "frexida-terraform-state"
+    key            = "projects/app-foobar/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/projects/app-foobar/terraform/main.tf
+++ b/projects/app-foobar/terraform/main.tf
@@ -1,0 +1,122 @@
+###############################################################################
+# App Foobar CI/CD Infrastructure
+#
+# This configuration creates a self-healing CI/CD pipeline for the
+# app-foobar project using the shared self-healing-cicd module.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Variables
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "github_token" {
+  description = "GitHub Personal Access Token"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_webhook_secret" {
+  description = "Secret for GitHub webhook validation (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ai_agent_endpoint" {
+  description = "AI Agent API endpoint URL"
+  type        = string
+  default     = "https://api.frexida.com/ci_result"
+}
+
+variable "ai_agent_api_key" {
+  description = "API key for AI agent service (optional)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# Get current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# Self-healing CI/CD module for app-foobar
+module "app_foobar_cicd" {
+  source = "../../../modules/self-healing-cicd"
+
+  # Environment configuration
+  environment = var.environment
+  aws_region  = var.aws_region
+  account_id  = data.aws_caller_identity.current.account_id
+
+  # Project configuration
+  project_name = "app-foobar"
+
+  # GitHub configuration
+  github_repository = "https://github.com/Frexida/app-foobar.git"
+  github_branch     = "main"
+  github_token      = var.github_token
+  webhook_secret    = var.github_webhook_secret
+
+  # AI Agent configuration
+  ai_agent_endpoint = var.ai_agent_endpoint
+  ai_agent_api_key  = var.ai_agent_api_key
+
+  # Build configuration (optimized for cost)
+  build_compute_type = "BUILD_GENERAL1_SMALL"  # 2 vCPU, 3GB RAM
+  build_timeout      = 30                      # 30 minutes max
+  max_retry_count    = 3                       # Max 3 automatic retries
+  log_retention_days = 7                       # Keep logs for 7 days
+}
+
+###############################################################################
+# Outputs
+###############################################################################
+
+output "codebuild_project_name" {
+  description = "Name of the CodeBuild project"
+  value       = module.app_foobar_cicd.codebuild_project_name
+}
+
+output "webhook_url" {
+  description = "GitHub webhook URL - Add this to your repository settings"
+  value       = module.app_foobar_cicd.webhook_url
+  sensitive   = true
+}
+
+output "cloudwatch_dashboard_url" {
+  description = "CloudWatch dashboard URL for monitoring"
+  value       = module.app_foobar_cicd.cloudwatch_dashboard_url
+}
+
+output "lambda_function_name" {
+  description = "Name of the Lambda function for error handling"
+  value       = module.app_foobar_cicd.lambda_function_name
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for build failure notifications"
+  value       = module.app_foobar_cicd.sns_topic_arn
+}

--- a/projects/homepage/terraform/backend.tf
+++ b/projects/homepage/terraform/backend.tf
@@ -1,0 +1,10 @@
+# Remote state backend for homepage project
+terraform {
+  backend "s3" {
+    bucket         = "frexida-terraform-state"
+    key            = "projects/homepage/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/projects/homepage/terraform/main.tf
+++ b/projects/homepage/terraform/main.tf
@@ -1,0 +1,122 @@
+###############################################################################
+# Frexida Homepage CI/CD Infrastructure
+#
+# This configuration creates a self-healing CI/CD pipeline for the
+# homepage project using the shared self-healing-cicd module.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Variables
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "github_token" {
+  description = "GitHub Personal Access Token"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_webhook_secret" {
+  description = "Secret for GitHub webhook validation (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ai_agent_endpoint" {
+  description = "AI Agent API endpoint URL"
+  type        = string
+  default     = "https://api.frexida.com/ci_result"
+}
+
+variable "ai_agent_api_key" {
+  description = "API key for AI agent service (optional)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# Get current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# Self-healing CI/CD module for homepage
+module "homepage_cicd" {
+  source = "../../../modules/self-healing-cicd"
+
+  # Environment configuration
+  environment = var.environment
+  aws_region  = var.aws_region
+  account_id  = data.aws_caller_identity.current.account_id
+
+  # Project configuration
+  project_name = "homepage"
+
+  # GitHub configuration
+  github_repository = "https://github.com/Frexida/homepage.git"
+  github_branch     = "main"
+  github_token      = var.github_token
+  webhook_secret    = var.github_webhook_secret
+
+  # AI Agent configuration
+  ai_agent_endpoint = var.ai_agent_endpoint
+  ai_agent_api_key  = var.ai_agent_api_key
+
+  # Build configuration (optimized for cost)
+  build_compute_type = "BUILD_GENERAL1_SMALL"  # 2 vCPU, 3GB RAM
+  build_timeout      = 30                      # 30 minutes max
+  max_retry_count    = 3                       # Max 3 automatic retries
+  log_retention_days = 7                       # Keep logs for 7 days
+}
+
+###############################################################################
+# Outputs
+###############################################################################
+
+output "codebuild_project_name" {
+  description = "Name of the CodeBuild project"
+  value       = module.homepage_cicd.codebuild_project_name
+}
+
+output "webhook_url" {
+  description = "GitHub webhook URL - Add this to your repository settings"
+  value       = module.homepage_cicd.webhook_url
+  sensitive   = true
+}
+
+output "cloudwatch_dashboard_url" {
+  description = "CloudWatch dashboard URL for monitoring"
+  value       = module.homepage_cicd.cloudwatch_dashboard_url
+}
+
+output "lambda_function_name" {
+  description = "Name of the Lambda function for error handling"
+  value       = module.homepage_cicd.lambda_function_name
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for build failure notifications"
+  value       = module.homepage_cicd.sns_topic_arn
+}

--- a/projects/picture-calendar/README.md
+++ b/projects/picture-calendar/README.md
@@ -1,0 +1,98 @@
+# Picture Calendar CI/CD Infrastructure
+
+This directory contains the Terraform configuration for the picture-calendar project's self-healing CI/CD pipeline.
+
+## Overview
+
+The picture-calendar project uses the shared `self-healing-cicd` module to provision:
+- AWS CodeBuild for automated builds
+- Lambda function for error handling and automatic recovery
+- SNS topics for build failure notifications
+- CloudWatch monitoring and dashboards
+
+## Prerequisites
+
+1. AWS credentials configured (preferably via OIDC)
+2. GitHub Personal Access Token with repo permissions
+3. S3 backend bucket and DynamoDB table for state management
+
+## Usage
+
+### 1. Set Environment Variables
+
+```bash
+export TF_VAR_github_token="your-github-pat-token"
+export TF_VAR_ai_agent_endpoint="https://api.frexida.com/ci_result"
+# Optional: only if API requires authentication
+export TF_VAR_ai_agent_api_key="your-ai-agent-api-key"
+```
+
+### 2. Initialize Terraform
+
+```bash
+cd terraform
+terraform init
+```
+
+### 3. Plan and Apply
+
+```bash
+terraform plan
+terraform apply
+```
+
+### 4. Configure GitHub Webhook
+
+After applying Terraform, get the webhook URL:
+
+```bash
+terraform output -raw webhook_url
+```
+
+Add this URL to your GitHub repository:
+1. Go to Settings > Webhooks
+2. Add webhook with the URL
+3. Select "Push" events
+4. Content type: application/json
+
+## Build Configuration
+
+The build process is defined in the `buildspec.yml` file in the picture-calendar repository root. It includes:
+- Python 3.11 runtime
+- Build and test phases
+- Automatic failure detection for branches containing "test-failure" or "fail"
+
+## Monitoring
+
+View the CloudWatch dashboard:
+
+```bash
+terraform output cloudwatch_dashboard_url
+```
+
+## Cost Optimization
+
+- Build compute: BUILD_GENERAL1_SMALL (2 vCPU, 3GB RAM)
+- Log retention: 7 days
+- Estimated monthly cost: ~2,000-3,000 JPY
+
+## Troubleshooting
+
+### Build Failures
+1. Check CloudWatch logs for the CodeBuild project
+2. Review Lambda function logs for error handler execution
+3. Verify GitHub webhook delivery status
+
+### State Issues
+If you encounter state locking issues:
+```bash
+aws dynamodb delete-item \
+  --table-name terraform-lock \
+  --key '{"LockID": {"S": "frexida-terraform-state/projects/picture-calendar/terraform.tfstate"}}'
+```
+
+## Related Documentation
+
+- [Main Infrastructure Documentation](../../README.md)
+- [Self-Healing CI/CD Module](../../modules/self-healing-cicd/README.md)
+- [Platform Infrastructure](../../platform/self-healing-cicd/README.md)

--- a/projects/picture-calendar/terraform/backend.tf
+++ b/projects/picture-calendar/terraform/backend.tf
@@ -1,0 +1,10 @@
+# Remote state backend for picture-calendar project
+terraform {
+  backend "s3" {
+    bucket         = "frexida-terraform-state"
+    key            = "projects/picture-calendar/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/projects/picture-calendar/terraform/main.tf
+++ b/projects/picture-calendar/terraform/main.tf
@@ -1,0 +1,122 @@
+###############################################################################
+# Picture Calendar Project CI/CD Infrastructure
+#
+# This configuration creates a self-healing CI/CD pipeline for the
+# picture-calendar project using the shared self-healing-cicd module.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Variables
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "github_token" {
+  description = "GitHub Personal Access Token"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_webhook_secret" {
+  description = "Secret for GitHub webhook validation (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ai_agent_endpoint" {
+  description = "AI Agent API endpoint URL"
+  type        = string
+  default     = "https://api.frexida.com/ci_result"
+}
+
+variable "ai_agent_api_key" {
+  description = "API key for AI agent service (optional)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# Get current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# Self-healing CI/CD module for picture-calendar
+module "picture_calendar_cicd" {
+  source = "../../../modules/self-healing-cicd"
+
+  # Environment configuration
+  environment = var.environment
+  aws_region  = var.aws_region
+  account_id  = data.aws_caller_identity.current.account_id
+
+  # Project configuration
+  project_name = "picture-calendar"
+
+  # GitHub configuration
+  github_repository = "https://github.com/Frexida/picture-calendar.git"
+  github_branch     = "main"
+  github_token      = var.github_token
+  webhook_secret    = var.github_webhook_secret
+
+  # AI Agent configuration
+  ai_agent_endpoint = var.ai_agent_endpoint
+  ai_agent_api_key  = var.ai_agent_api_key
+
+  # Build configuration (optimized for cost)
+  build_compute_type = "BUILD_GENERAL1_SMALL"  # 2 vCPU, 3GB RAM
+  build_timeout      = 30                      # 30 minutes max
+  max_retry_count    = 3                       # Max 3 automatic retries
+  log_retention_days = 7                       # Keep logs for 7 days
+}
+
+###############################################################################
+# Outputs
+###############################################################################
+
+output "codebuild_project_name" {
+  description = "Name of the CodeBuild project"
+  value       = module.picture_calendar_cicd.codebuild_project_name
+}
+
+output "webhook_url" {
+  description = "GitHub webhook URL - Add this to your repository settings"
+  value       = module.picture_calendar_cicd.webhook_url
+  sensitive   = true
+}
+
+output "cloudwatch_dashboard_url" {
+  description = "CloudWatch dashboard URL for monitoring"
+  value       = module.picture_calendar_cicd.cloudwatch_dashboard_url
+}
+
+output "lambda_function_name" {
+  description = "Name of the Lambda function for error handling"
+  value       = module.picture_calendar_cicd.lambda_function_name
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for build failure notifications"
+  value       = module.picture_calendar_cicd.sns_topic_arn
+}

--- a/scripts/create-iam-role.sh
+++ b/scripts/create-iam-role.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# IAMロール作成スクリプト（OIDC設定済み前提）
+# 使用方法: ./create-iam-role.sh
+
+set -e
+
+# 設定
+AWS_ACCOUNT_ID="522579114515"
+ROLE_NAME="github-actions-terraform-role"
+
+echo "🚀 GitHub Actions用のIAMロール作成"
+echo "=================================="
+echo "AWS Account ID: $AWS_ACCOUNT_ID"
+echo "Role Name: $ROLE_NAME"
+echo ""
+
+# Step 1: 信頼ポリシーをブランチも含めて更新
+echo "Step 1: 信頼ポリシーを作成..."
+cat > /tmp/trust-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:Frexida/infra:*",
+            "repo:Frexida/picture-calendar:*",
+            "repo:Frexida/homepage:*",
+            "repo:Frexida/app-foobar:*"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+echo "✅ 信頼ポリシー作成完了"
+
+# Step 2: IAMロール作成
+echo ""
+echo "Step 2: IAMロール作成..."
+if aws iam get-role --role-name "${ROLE_NAME}" 2>/dev/null; then
+    echo "⚠️  ロールは既に存在します。信頼ポリシーを更新..."
+    aws iam update-assume-role-policy \
+        --role-name "${ROLE_NAME}" \
+        --policy-document file:///tmp/trust-policy.json
+    echo "✅ 信頼ポリシー更新完了"
+else
+    aws iam create-role \
+        --role-name "${ROLE_NAME}" \
+        --assume-role-policy-document file:///tmp/trust-policy.json \
+        --description "GitHub Actions用のTerraform実行ロール"
+    echo "✅ IAMロール作成完了"
+fi
+
+# Step 3: 権限ポリシー作成（CodeBuild, Lambda等に必要な権限）
+echo ""
+echo "Step 3: 権限ポリシー作成..."
+cat > /tmp/permissions.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TerraformState",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*",
+        "dynamodb:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::frexida-terraform-state",
+        "arn:aws:s3:::frexida-terraform-state/*",
+        "arn:aws:dynamodb:ap-northeast-1:${AWS_ACCOUNT_ID}:table/terraform-lock"
+      ]
+    },
+    {
+      "Sid": "SelfHealingCICD",
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:*",
+        "lambda:*",
+        "iam:*",
+        "logs:*",
+        "cloudwatch:*",
+        "events:*",
+        "sns:*",
+        "secretsmanager:*",
+        "s3:*",
+        "dynamodb:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+# 管理ポリシーとして作成
+POLICY_NAME="github-actions-terraform-policy"
+if aws iam get-policy --policy-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${POLICY_NAME}" 2>/dev/null; then
+    echo "⚠️  ポリシーは既に存在します"
+    POLICY_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${POLICY_NAME}"
+else
+    aws iam create-policy \
+        --policy-name "${POLICY_NAME}" \
+        --policy-document file:///tmp/permissions.json \
+        --description "GitHub Actions Terraform実行権限"
+    POLICY_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${POLICY_NAME}"
+    echo "✅ ポリシー作成完了"
+fi
+
+# ポリシーをロールにアタッチ
+aws iam attach-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-arn "${POLICY_ARN}" 2>/dev/null || true
+echo "✅ ポリシーアタッチ完了"
+
+# Step 4: S3バケットとDynamoDBテーブル作成
+echo ""
+echo "Step 4: Terraformバックエンドリソース作成..."
+
+# S3バケット
+if aws s3api head-bucket --bucket "frexida-terraform-state" 2>/dev/null; then
+    echo "✅ S3バケット 'frexida-terraform-state' は既に存在"
+else
+    aws s3api create-bucket \
+        --bucket "frexida-terraform-state" \
+        --region ap-northeast-1 \
+        --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+    aws s3api put-bucket-versioning \
+        --bucket "frexida-terraform-state" \
+        --versioning-configuration Status=Enabled
+
+    echo "✅ S3バケット作成完了"
+fi
+
+# DynamoDBテーブル
+if aws dynamodb describe-table --table-name "terraform-lock" --region ap-northeast-1 2>/dev/null; then
+    echo "✅ DynamoDBテーブル 'terraform-lock' は既に存在"
+else
+    aws dynamodb create-table \
+        --table-name "terraform-lock" \
+        --attribute-definitions AttributeName=LockID,AttributeType=S \
+        --key-schema AttributeName=LockID,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST \
+        --region ap-northeast-1
+
+    echo "✅ DynamoDBテーブル作成完了"
+fi
+
+echo ""
+echo "=================================="
+echo "✅ セットアップ完了！"
+echo "=================================="
+echo ""
+echo "📝 GitHubリポジトリに以下を設定してください："
+echo ""
+echo "1. Settings → Secrets and variables → Actions → Secrets"
+echo ""
+echo "   AWS_ROLE_ARN:"
+echo "   arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ROLE_NAME}"
+echo ""
+echo "   GH_PAT:"
+echo "   https://github.com/settings/tokens/new"
+echo "   （repoスコープ付きのPersonal Access Token）"
+echo ""
+echo "2. Settings → Secrets and variables → Actions → Variables"
+echo ""
+echo "   AI_AGENT_ENDPOINT:"
+echo "   https://api.frexida.com/ci-result"
+echo ""
+echo "=================================="

--- a/scripts/setup-aws-oidc.sh
+++ b/scripts/setup-aws-oidc.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+
+# AWS IAM OIDC Provider and Role Setup Script for GitHub Actions
+# Usage: ./setup-aws-oidc.sh
+
+set -e
+
+# Configuration
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+OIDC_PROVIDER="token.actions.githubusercontent.com"
+GITHUB_ORG="Frexida"
+GITHUB_REPO="infra"
+ROLE_NAME="github-actions-terraform-role"
+POLICY_NAME="github-actions-terraform-policy"
+
+echo "🚀 Starting AWS OIDC and IAM Role setup for GitHub Actions"
+echo "=================================================="
+echo "AWS Account ID: $AWS_ACCOUNT_ID"
+echo "GitHub Repo: $GITHUB_ORG/$GITHUB_REPO"
+echo "Role Name: $ROLE_NAME"
+echo ""
+
+# Step 1: Create OIDC Provider
+echo "Step 1: Creating OIDC Provider..."
+THUMBPRINT="6938fd4d98bab03faadb97b34396831e3780aea1"
+
+# Check if OIDC provider already exists
+if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}" 2>/dev/null; then
+    echo "✅ OIDC Provider already exists"
+else
+    aws iam create-open-id-connect-provider \
+        --url "https://${OIDC_PROVIDER}" \
+        --client-id-list "sts.amazonaws.com" \
+        --thumbprint-list "${THUMBPRINT}"
+    echo "✅ OIDC Provider created"
+fi
+
+# Step 2: Create Trust Policy
+echo ""
+echo "Step 2: Creating Trust Policy..."
+cat > /tmp/trust-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${OIDC_PROVIDER}:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "${OIDC_PROVIDER}:sub": [
+            "repo:${GITHUB_ORG}/${GITHUB_REPO}:*",
+            "repo:${GITHUB_ORG}/picture-calendar:*",
+            "repo:${GITHUB_ORG}/homepage:*",
+            "repo:${GITHUB_ORG}/app-foobar:*"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+echo "✅ Trust policy created at /tmp/trust-policy.json"
+
+# Step 3: Create IAM Role
+echo ""
+echo "Step 3: Creating IAM Role..."
+if aws iam get-role --role-name "${ROLE_NAME}" 2>/dev/null; then
+    echo "⚠️  Role already exists, updating trust policy..."
+    aws iam update-assume-role-policy \
+        --role-name "${ROLE_NAME}" \
+        --policy-document file:///tmp/trust-policy.json
+    echo "✅ Trust policy updated"
+else
+    aws iam create-role \
+        --role-name "${ROLE_NAME}" \
+        --assume-role-policy-document file:///tmp/trust-policy.json \
+        --description "IAM role for GitHub Actions to deploy infrastructure via Terraform"
+    echo "✅ IAM Role created"
+fi
+
+# Step 4: Create Permissions Policy
+echo ""
+echo "Step 4: Creating Permissions Policy..."
+cat > /tmp/permissions-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TerraformStateAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": [
+        "arn:aws:s3:::frexida-terraform-state",
+        "arn:aws:s3:::frexida-terraform-state/*"
+      ]
+    },
+    {
+      "Sid": "DynamoDBLockAccess",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "arn:aws:dynamodb:ap-northeast-1:${AWS_ACCOUNT_ID}:table/terraform-lock"
+    },
+    {
+      "Sid": "CodeBuildManagement",
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "LambdaManagement",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IAMManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:PassRole",
+        "iam:UpdateRole",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:ListInstanceProfilesForRole",
+        "iam:TagRole",
+        "iam:UntagRole"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchManagement",
+      "Effect": "Allow",
+      "Action": [
+        "logs:*",
+        "cloudwatch:*",
+        "events:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SNSManagement",
+      "Effect": "Allow",
+      "Action": [
+        "sns:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManagerAccess",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:TagResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3BuildArtifacts",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetBucketPolicy",
+        "s3:PutBucketPolicy",
+        "s3:GetBucketVersioning",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DynamoDBRetryTable",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:UpdateTable",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource",
+        "dynamodb:ListTables",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:UpdateTimeToLive"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+echo "✅ Permissions policy created at /tmp/permissions-policy.json"
+
+# Step 5: Attach Policy to Role
+echo ""
+echo "Step 5: Attaching Policy to Role..."
+
+# Check if policy exists
+if aws iam get-policy --policy-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${POLICY_NAME}" 2>/dev/null; then
+    echo "⚠️  Policy already exists, updating..."
+    POLICY_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${POLICY_NAME}"
+
+    # Create new version
+    aws iam create-policy-version \
+        --policy-arn "${POLICY_ARN}" \
+        --policy-document file:///tmp/permissions-policy.json \
+        --set-as-default
+    echo "✅ Policy updated"
+else
+    # Create new policy
+    aws iam create-policy \
+        --policy-name "${POLICY_NAME}" \
+        --policy-document file:///tmp/permissions-policy.json \
+        --description "Permissions for GitHub Actions to manage infrastructure"
+    POLICY_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${POLICY_NAME}"
+    echo "✅ Policy created"
+fi
+
+# Attach policy to role
+aws iam attach-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-arn "${POLICY_ARN}"
+echo "✅ Policy attached to role"
+
+# Step 6: Create S3 Backend Resources
+echo ""
+echo "Step 6: Creating S3 Backend Resources..."
+
+# Create S3 bucket for Terraform state
+if aws s3api head-bucket --bucket "frexida-terraform-state" 2>/dev/null; then
+    echo "✅ S3 bucket 'frexida-terraform-state' already exists"
+else
+    aws s3api create-bucket \
+        --bucket "frexida-terraform-state" \
+        --region ap-northeast-1 \
+        --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+    # Enable versioning
+    aws s3api put-bucket-versioning \
+        --bucket "frexida-terraform-state" \
+        --versioning-configuration Status=Enabled
+
+    # Enable encryption
+    aws s3api put-bucket-encryption \
+        --bucket "frexida-terraform-state" \
+        --server-side-encryption-configuration '{
+            "Rules": [
+                {
+                    "ApplyServerSideEncryptionByDefault": {
+                        "SSEAlgorithm": "AES256"
+                    }
+                }
+            ]
+        }'
+
+    echo "✅ S3 bucket created with versioning and encryption"
+fi
+
+# Create DynamoDB table for state locking
+if aws dynamodb describe-table --table-name "terraform-lock" 2>/dev/null; then
+    echo "✅ DynamoDB table 'terraform-lock' already exists"
+else
+    aws dynamodb create-table \
+        --table-name "terraform-lock" \
+        --attribute-definitions AttributeName=LockID,AttributeType=S \
+        --key-schema AttributeName=LockID,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST \
+        --region ap-northeast-1
+
+    echo "✅ DynamoDB table created"
+fi
+
+# Output summary
+echo ""
+echo "=================================================="
+echo "✅ Setup Complete!"
+echo "=================================================="
+echo ""
+echo "📝 Next Steps:"
+echo ""
+echo "1. Add the following secrets to your GitHub repository:"
+echo "   (Settings -> Secrets and variables -> Actions)"
+echo ""
+echo "   AWS_ROLE_ARN:"
+echo "   arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ROLE_NAME}"
+echo ""
+echo "   GH_PAT:"
+echo "   Create a Personal Access Token with 'repo' scope at:"
+echo "   https://github.com/settings/tokens/new"
+echo ""
+echo "2. Add the following variable:"
+echo "   AI_AGENT_ENDPOINT:"
+echo "   https://api.frexida.com/ci-result"
+echo ""
+echo "3. Optional: Add AI_AGENT_API_KEY if your API requires authentication"
+echo ""
+echo "=================================================="
+echo "🎉 Your AWS infrastructure is ready for GitHub Actions!"


### PR DESCRIPTION
## 概要
このPRは、インフラリポジトリの構成を再編成し、GitHub Actionsの責務を明確化します。

## 主な変更点

### 🏗️ ディレクトリ構造の再編成
- `platform/self-healing-cicd`: 組織全体の基盤インフラ
- `projects/{picture-calendar,homepage,app-foobar}`: プロジェクト別設定
- `modules/`: 共通モジュール（変更なし）

### 🚀 GitHub Actions責務の明確化
- **infraリポジトリのみ**がTerraformを実行
- アプリリポジトリはビルド・テストのみ担当
- `platform-deploy.yml`: プラットフォーム基盤のデプロイ
- `project-deploy.yml`: プロジェクト別インフラのデプロイ

### 📦 各プロジェクトの独立性向上
- プロジェクトごとに独立したTerraformステート
- 共通モジュールを再利用（重複なし）
- 並行デプロイが可能

### 💰 コスト最適化
- 月額2,000-3,000円の目標を維持
- Lambda/SNSなど基盤リソースは共有

## テスト項目
- [ ] Terraform planが正常に実行される
- [ ] 既存リソースへの変更がない（または意図した変更のみ）
- [ ] GitHub Actionsワークフローが正しく動作する

## 関連情報
- API Endpoint: `https://api.frexida.com/ci-result` (設定済み)
- AWS Account: 522579114515
- Region: ap-northeast-1

🤖 Generated with Claude Code